### PR TITLE
Add release data for minimum versions

### DIFF
--- a/docs/mozillavpn.json
+++ b/docs/mozillavpn.json
@@ -14,15 +14,25 @@
     "WINDOWS": "2.7.1"
   },
   "releases": {
-    "2.5.1": {
+    "2.0.0": {
       "build": null,
-      "date": "2021-10-20",
-      "platforms": ["ANDROID", "IOS"]
+      "date": "2019-10-04",
+      "platforms": ["ANDROID", "IOS", "LINUX"]
+    },
+    "2.1.0": {
+      "build": null,
+      "date": "2021-03-07",
+      "platforms": ["MACOS"]
     },
     "2.5.0": {
       "build": null,
       "date": "2021-09-15",
       "platforms": ["ANDROID", "IOS", "LINUX", "MACOS", "WINDOWS"]
+    },
+    "2.5.1": {
+      "build": null,
+      "date": "2021-10-20",
+      "platforms": ["ANDROID", "IOS"]
     },
     "2.6.0": {
       "build": null,

--- a/docs/mozillavpn.json
+++ b/docs/mozillavpn.json
@@ -16,12 +16,12 @@
   "releases": {
     "2.0.0": {
       "build": null,
-      "date": "2019-10-04",
+      "date": "2020-11-04",
       "platforms": ["ANDROID", "IOS", "LINUX"]
     },
     "2.1.0": {
       "build": null,
-      "date": "2021-03-07",
+      "date": "2021-04-07",
       "platforms": ["MACOS"]
     },
     "2.5.0": {

--- a/docs/mozillavpn_stage.json
+++ b/docs/mozillavpn_stage.json
@@ -14,6 +14,16 @@
     "WINDOWS": "2.7.1"
   },
   "releases": {
+    "2.0.0": {
+      "build": 1,
+      "date": "2019-10-04",
+      "platforms": ["ANDROID", "IOS", "LINUX"]
+    },
+    "2.1.0": {
+      "build": 1,
+      "date": "2021-03-07",
+      "platforms": ["MACOS"]
+    },
     "2.6.0": {
       "build": 3,
       "date": "2021-11-10",

--- a/docs/mozillavpn_stage.json
+++ b/docs/mozillavpn_stage.json
@@ -16,12 +16,12 @@
   "releases": {
     "2.0.0": {
       "build": 1,
-      "date": "2019-10-04",
+      "date": "2020-11-04",
       "platforms": ["ANDROID", "IOS", "LINUX"]
     },
     "2.1.0": {
       "build": 1,
-      "date": "2021-03-07",
+      "date": "2021-04-07",
       "platforms": ["MACOS"]
     },
     "2.6.0": {


### PR DESCRIPTION
PSP-178 requires that we pull and display data for the minimum version on each platform, so I am transferring the static data that lived in Guardian previously to here.