### PR TITLE
Block 2.10.0 for macos as a temporary solution until the renaming 'ma…

### DIFF
--- a/docs/mozillavpn.json
+++ b/docs/mozillavpn.json
@@ -3,7 +3,7 @@
     "ANDROID": "2.9.0",
     "IOS": "2.8.2",
     "LINUX": "2.10.0",
-    "MACOS": "2.10.0",
+    "MACOS": "2.9.0",
     "WINDOWS": "2.10.0"
   },
   "minimum": {


### PR DESCRIPTION
…cos' vs 'mac' issue is solved