### PR TITLE
Add workflow to generate appstream releases file

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,41 @@
+name: Github Pages
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Content
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Generate Appstream releases
+        shell: bash
+        run: python ./generate-appstream-releases.py docs/mozillavpn.json > docs/org.mozilla.vpn.releases.xml
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+  
+  deploy:
+    name: Deploy Pages
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,4 @@
 <ul>
 <li><a href="./mozillavpn.json">mozillavpn.json</a></li>
+<li><a href="./org.mozilla.vpn.releases.xml">org.mozilla.vpn.releases.xml</a></li>
 </ul>

--- a/generate-appstream-releases.py
+++ b/generate-appstream-releases.py
@@ -16,10 +16,10 @@ class release:
         self.version = version
         self.json = js
         self.platforms = [x.lower() for x in js['platforms']]
-    
+
     def matches(self, platform):
         return platform.lower() in self.platforms
-    
+
     def toxml(self):
         attrs = {
             'version': self.version,
@@ -32,25 +32,29 @@ class release:
         xurl.text = f"https://github.com/mozilla-mobile/mozilla-vpn-client/releases/v{self.version}"
         xml.append(xurl)
 
+        # TODO: It is recommended to include a release description in the Appstream
+        # manifest too. We could fetch this from the Github releases API, but they
+        # aren't very well formatted for this purpose.
+
         return xml
 
 if __name__ == "__main__":
     ## Parse arguments to locate the input files and options.
     parser = argparse.ArgumentParser(
-        description='Generate releases information for an appstream file')
+        description='Generate Appstream releases information from JSON')
 
     parser.add_argument('source', metavar='SOURCE', type=str, action='store',
-        help='Appstream metainfo file to parse')
+        help='JSON releases file to parse')
     parser.add_argument('--platform', metavar='PLATFORM', type=str,
         action='store', default='LINUX',
         help='Target platform for appstream releases')
     args = parser.parse_args()
 
-    # Parse the release file
+    # Parse the JSON releases file
     with open(args.source, 'r') as fp:
         data = json.load(fp)
 
-    # Build the releases XML document.
+    # Build the Appstream releases XML document.
     root = ElementTree.Element('releases')
     versions = list(data['releases'].keys())
     versions.sort(key=Version, reverse=True)
@@ -58,7 +62,7 @@ if __name__ == "__main__":
         info = release(version, data['releases'][version])
         if info.matches(args.platform):
             root.append(info.toxml())
-    
+
     # Dump the XML data to stdout
     ElementTree.indent(root, space="  ")
     ElementTree.dump(root)

--- a/generate-appstream-releases.py
+++ b/generate-appstream-releases.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import os
+import sys
+import json
+
+from packaging.version import Version
+from xml.etree import ElementTree
+
+class release:
+    def __init__(self, version, js):
+        self.version = version
+        self.json = js
+        self.platforms = [x.lower() for x in js['platforms']]
+    
+    def matches(self, platform):
+        return platform.lower() in self.platforms
+    
+    def toxml(self):
+        attrs = {
+            'version': self.version,
+            'date': self.json['date']
+        }
+        xml = ElementTree.Element('release', attrib=attrs)
+
+        # Add the details URL which should point to github
+        xurl = ElementTree.Element('url', attrib={'type': 'details'})
+        xurl.text = f"https://github.com/mozilla-mobile/mozilla-vpn-client/releases/v{self.version}"
+        xml.append(xurl)
+
+        return xml
+
+if __name__ == "__main__":
+    ## Parse arguments to locate the input files and options.
+    parser = argparse.ArgumentParser(
+        description='Generate releases information for an appstream file')
+
+    parser.add_argument('source', metavar='SOURCE', type=str, action='store',
+        help='Appstream metainfo file to parse')
+    parser.add_argument('--platform', metavar='PLATFORM', type=str,
+        action='store', default='LINUX',
+        help='Target platform for appstream releases')
+    args = parser.parse_args()
+
+    # Parse the release file
+    with open(args.source, 'r') as fp:
+        data = json.load(fp)
+
+    # Build the releases XML document.
+    root = ElementTree.Element('releases')
+    versions = list(data['releases'].keys())
+    versions.sort(key=Version, reverse=True)
+    for version in versions:
+        info = release(version, data['releases'][version])
+        if info.matches(args.platform):
+            root.append(info.toxml())
+    
+    # Dump the XML data to stdout
+    ElementTree.indent(root, space="  ")
+    ElementTree.dump(root)


### PR DESCRIPTION
I have a need for there to be a hosted XML releases file, conforming to the [Appstream Metadata format](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html), which someday might be consumed by Flatpaks and maybe SNAPs. We already serve a similar file in JSON format here using github pages, it's just not in the correct data shape.

This PR attempts to add a new workflow which can generate the file, starting with our current [mozillavpn.json](https://mozilla.github.io/mozillavpn-product-details/mozillavpn.json) file as the source of truth.

For this to take effect, we also need to update the Github Pages configuration to deploy from a workflow rather than uploading static artifacts. The configuration is as follows:
![Screenshot from 2024-08-23 18-48-54](https://github.com/user-attachments/assets/2d205d26-d2b6-414f-aa97-ebe4db8cbe12)
