### PR TITLE
Automate the flathub update checker

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -40,3 +40,15 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
         id: deployment
+
+      - name: Triger flathub updates
+        env:
+          FLATHUB_TOKEN: ${{ secrets.FLATHUB_TOKEN }}
+          FLATHUB_API_URL: https://api.github.com/repos/flathub/org.mozilla.vpn/actions/workflows/update-check.yml/dispatches
+        run: |
+          curl -sSL -X POST -d '{"ref":"master"}' \
+             -H "Accept: application/vnd.github+json" \
+             -H "Authorization: Bearer ${FLATHUB_TOKEN}" \
+             -H "X-GitHub-Api-Version: 2022-11-28" \
+             ${FLATHUB_API_URL}
+


### PR DESCRIPTION
This adds an extra step after deploying to github-pages to create a workflow dispatch that runs the flatpak update checker.

This should the same as going to https://github.com/flathub/org.mozilla.vpn/actions/workflows/update-check.yml and running the check on the `master` branch.

If there is an updated Linux release, this should trigger a new pull request to https://github.com/flathub/org.mozilla.vpn that updates the manifest accordingly and trigger test builds. Merging it will publish the new release to flathub.
